### PR TITLE
feat: Add automated build for MCP IES base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,51 @@
+# Use a specific ies base image
+FROM registry-vpc.miracle.ac.cn/infcprelease/ies:v1.0.0
+
+# Download the womtool JAR file from the Broad Institute repository
+RUN wget -P /usr/local/lib https://github.com/broadinstitute/cromwell/releases/download/85/womtool-85.jar 
+
+# Update package list with a retry mechanism to ensure availability
+RUN apt-get update || apt-get update
+
+# Install essential packages: iputils-ping for network diagnostics, OpenJDK 21 for Java execution
+# Clean up package cache to reduce image size
+RUN apt-get install -y iputils-ping openjdk-21-jdk \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/*
+
+# Install the pybioos Python package using conda's pip
+RUN /opt/conda/bin/pip install pybioos
+
+# Install the uv package, possibly for running a web server or API
+RUN /opt/conda/bin/pip install uv
+    
+# Install the Claude Dev VSCode extension for code-server in a specified directory
+RUN mkdir -p /opt/code-server/extensions && \
+    /app/code-server/bin/code-server --extensions-dir /opt/code-server/extensions --install-extension saoudrizwan.claude-dev
+
+# Clone the bioos-mcp-server repository into the specified directory
+RUN git clone https://github.com/GBA-BI/bioos-mcp-server.git /opt/lib/bioos-mcp-server
+
+# Copy and set appropriate permissions for the script that initializes code-server
+COPY --chmod=755 ./images/ies/etc/s6-overlay/s6-rc.d/init-code-server/run /etc/s6-overlay/s6-rc.d/init-code-server/run
+
+# Create configuration directory and write settings for the VSCode extension
+RUN mkdir -p /home/ies/.local/share/code-server/User/globalStorage/saoudrizwan.claude-dev/settings && \
+    cat <<EOF > /home/ies/.local/share/code-server/User/globalStorage/saoudrizwan.claude-dev/settings/cline_mcp_settings.json
+{
+  "mcpServers": {
+    "bioos": {
+      "command": "uv",
+      "args": [
+        "--directory",
+        "/opt/lib/bioos-mcp-server/src/bioos_mcp",
+        "run",
+        "/opt/lib/bioos-mcp-server/src/bioos_mcp/bioos_mcp_server.py"
+      ],
+      "env": {
+        "PYTHONPATH": "/opt/lib/bioos-mcp-server/src"
+      }
+    }
+  }
+}
+EOF

--- a/README.md
+++ b/README.md
@@ -4,14 +4,65 @@ A Model Context Protocol (MCP) based tool and prompt server for Bio-OS that prov
 
 ## Installation
 
-1. Install dependencies:
-```bash
-pip install -r requirements.txt
+### Using MCP through Miracle Cloud Interactive Analysis Instance
+When using Miracle Cloud, you can directly use the custom URL [registry-vpc.miracle.ac.cn/infcprelease/iespro:250208](registry-vpc.miracle.ac.cn/infcprelease/iespro:250208) in the interactive analysis instance. The image has already integrated the MCP scripts and related dependencies. You only need to configure your own  LLM model access credentials to start using it.
+
+### Local Installation（Use through local VSCode and Cline plugin）
+#### Pre-requisite  
+Before using this setup, ensure that the following dependencies are installed:
+
+1. VSCode IDE  
+Download and install from: [VSCode Official Site](https://code.visualstudio.com/)
+
+2. Cline Plugin (Required for interacting with Miracle Cloud via VSCode)  
+Install using the following command:  
+    ```sh
+    code --install-extension saoudrizwan.claude-dev
+    ```
+    Users need to configure their own LLM model access credentials.
+
+3. Pybioos (Bio-OS Python SDK for interacting with Bio-OS services)  
+Install using pip:  
+    ```sh
+    pip install pybioos
+    ```
+
+4. JDK (Java Development Kit, required for certain backend services)  
+Recommended version: OpenJDK 11 or later  
+
+- Install on Ubuntu/Debian:  
+  ```sh
+  sudo apt update && sudo apt install openjdk-11-jdk
+  ```
+
+- Install on macOS (via Homebrew):  
+    ```sh
+    brew install openjdk@11
+    ```
+
+- Install on Windows:  Download from: [Adoptium OpenJDK](https://adoptium.net/)
+
+5. Womtool
+    ```sh
+    wget https://github.com/broadinstitute/cromwell/releases/download/85/womtool-85.jar 
+    ```
+    You can install womtool using conda, which will automatically generate a womtool script to build the scheduling logic for the JAR file, or you can add alias or doskey information manually.
+    
+    For Linux/macOS (using alias):
+    ```sh
+    alias womtool='java -jar womtool-85.jar'
+    ```
+    For Windows (using doskey):
+    ```
+    doskey womtool=java -jar womtool-85.jar
+    ```
+#### Obtaining MCP
+
+```sh
+git clone https://github.com/GBA-BI/bioos-mcp-server.git
 ```
 
-2. Ensure the following tools are installed in your system:
-- womtool (for WDL workflow validation)
-- pybioos (for Bio-OS python SDK)
+
 
 ## Features
 

--- a/images/ies/etc/s6-overlay/s6-rc.d/init-code-server/run
+++ b/images/ies/etc/s6-overlay/s6-rc.d/init-code-server/run
@@ -1,0 +1,39 @@
+#!/usr/bin/with-contenv bash
+# shellcheck shell=bash
+
+# This registers the initialization code for the conda shell code
+# It also activates default environment in the end, so we don't need to activate it manually
+# Documentation: https://docs.conda.io/projects/conda/en/latest/dev-guide/deep-dives/activation.html
+mkdir -p /home/${NB_USER}/.local/share/code-server/extensions
+cp /opt/code-server/extensions/extensions.json /home/ies/.local/share/code-server/extensions/
+ln -s /opt/code-server/extensions/saoudrizwan.claude-dev-3.2.13-universal /home/ies/.local/share/code-server/extensions/
+mkdir -p /home/${NB_USER}/.ssh
+
+mkdir -p /home/ies/.local/share/code-server/User/globalStorage/saoudrizwan.claude-dev/settings && \
+    cat <<EOF > /home/ies/.local/share/code-server/User/globalStorage/saoudrizwan.claude-dev/settings/cline_mcp_settings.json
+{
+  "mcpServers": {
+    "bioos": {
+      "command": "uv",
+      "args": [
+        "--directory",
+        "/opt/lib/bioos-mcp-server/src/bioos_mcp",
+        "run",
+        "/opt/lib/bioos-mcp-server/src/bioos_mcp/bioos_mcp_server.py"
+      ],
+      "env": {
+        "PYTHONPATH": "/opt/lib/bioos-mcp-server/src"
+      }
+    }
+  }
+}
+EOF
+
+echo "alias womtool='java -jar /usr/local/lib/womtool-85.jar'" >> "/home/${NB_USER}/.bashrc"
+chown "${NB_USER}:${NB_USER}" "/home/${NB_USER}/.bashrc"
+
+chown "${NB_USER}:${NB_USER}" "/home/${NB_USER}"
+chown -Rf "${NB_USER}:${NB_USER}" "/home/${NB_USER}/.local"
+chown -Rf "${NB_USER}:${NB_USER}" "/home/${NB_USER}/.ssh"
+chown -Rf "${NB_USER}:${NB_USER}" /opt/lib/bioos-mcp-server
+chmod -R 755 "/home/${NB_USER}/.local"


### PR DESCRIPTION
Based on MCP service requirements, this PR enhances the IES base image with the following additions:

- pybioos v0.0.14 for MCP-related functionalities.
- womtool v85 to support workflow operations.
- Uv for running web services or APIs.
- ping for network diagnostics.

![image](https://github.com/user-attachments/assets/84b3cab1-7565-4d13-b61b-0a37cca77d76)
