### PR TITLE
feat: Use Python to directly start MCP in the IES environment

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,7 +17,7 @@ RUN apt-get install -y iputils-ping openjdk-21-jdk \
 RUN /opt/conda/bin/pip install pybioos
 
 # Install the uv package, possibly for running a web server or API
-RUN /opt/conda/bin/pip install uv
+RUN /opt/conda/bin/pip install uv mcp
     
 # Install the Claude Dev VSCode extension for code-server in a specified directory
 RUN mkdir -p /opt/code-server/extensions && \

--- a/images/ies/etc/s6-overlay/s6-rc.d/init-code-server/run
+++ b/images/ies/etc/s6-overlay/s6-rc.d/init-code-server/run
@@ -4,48 +4,69 @@
 # This registers the initialization code for the conda shell code
 # It also activates default environment in the end, so we don't need to activate it manually
 # Documentation: https://docs.conda.io/projects/conda/en/latest/dev-guide/deep-dives/activation.html
+
+# Create necessary directories
 mkdir -p /home/${NB_USER}/.local/share/code-server/extensions
 mkdir -p /home/${NB_USER}/.ssh
-cp /opt/code-server/extensions/extensions.json /home/${NB_USER}/.local/share/code-server/extensions/
 
-ln -sf /opt/code-server/extensions/saoudrizwan.claude-dev-3.4.4-universal /home/${NB_USER}/.local/share/code-server/extensions/
-
-mkdir -p /home/${NB_USER}/.local/share/code-server/User/globalStorage/saoudrizwan.claude-dev/settings && \
-    cat <<EOF > /home/${NB_USER}/.local/share/code-server/User/globalStorage/saoudrizwan.claude-dev/settings/cline_mcp_settings.json
+if [[ ! -f "/home/${NB_USER}/.local/share/code-server/User/globalStorage/saoudrizwan.claude-dev/settings/cline_mcp_settings.json" ]]; then
+    echo "Initialization of MCP-related plugins"
+    
+    # Copy and link extensions
+    cp /opt/code-server/extensions/extensions.json /home/${NB_USER}/.local/share/code-server/extensions/
+    find /opt/code-server/extensions -name 'saoudrizwan.claude-dev-*-universal' -type d -exec ln -sf {} "/home/${NB_USER}/.local/share/code-server/extensions/" \;
+    
+    # Create settings directory and write configuration
+    mkdir -p /home/${NB_USER}/.local/share/code-server/User/globalStorage/saoudrizwan.claude-dev/settings
+    cat <<'EOF' > /home/${NB_USER}/.local/share/code-server/User/globalStorage/saoudrizwan.claude-dev/settings/cline_mcp_settings.json
 {
   "mcpServers": {
     "bioos": {
-      "command": "/opt/conda/bin/uv",
+      "command": "/opt/conda/bin/python",
       "args": [
-        "--directory",
-        "/opt/lib/bioos-mcp-server/src/bioos_mcp",
-        "run",
         "/opt/lib/bioos-mcp-server/src/bioos_mcp/bioos_mcp_server.py"
       ],
       "env": {
         "PYTHONPATH": "/opt/lib/bioos-mcp-server/src"
-      }
+      },
+      "disabled": false,
+      "autoApprove": []
     }
   }
 }
 EOF
 
-echo "alias womtool='java -jar /usr/local/lib/womtool-85.jar'" >> "/home/${NB_USER}/.bashrc"
-chown -Rf "${NB_USER}:${NB_USER}" /opt/lib/bioos-mcp-server
+    # Set permissions for server directory
+    chown -Rf "${NB_USER}:${NB_USER}" /opt/lib/bioos-mcp-server
 
-# Expand the preset extensions for Code Server to centralized SSH remote environments based on VSCode-related IDEs. 
-ssh_remote_servers=(".vscode-server" ".cursor-server" ".vscode-server-insiders")
+    # Expand the preset extensions for Code Server to centralized SSH remote environments
+    for server in .vscode-server .cursor-server .vscode-server-insiders; do
+        # Create directories
+        mkdir -p "/home/${NB_USER}/${server}/extensions"
+        mkdir -p "/home/${NB_USER}/${server}/data/User/globalStorage/saoudrizwan.claude-dev/settings"
+        
+        # Copy settings and extensions
+        cp "/home/${NB_USER}/.local/share/code-server/User/globalStorage/saoudrizwan.claude-dev/settings/cline_mcp_settings.json" \
+           "/home/${NB_USER}/${server}/data/User/globalStorage/saoudrizwan.claude-dev/settings"
+        cp "/opt/code-server/extensions/extensions.json" "/home/${NB_USER}/${server}/extensions"
+        find /opt/code-server/extensions -name 'saoudrizwan.claude-dev-*-universal' -type d -exec ln -sf {} "/home/${NB_USER}/${server}/extensions" \;
+        
+        # Set permissions
+        chown -Rf "${NB_USER}:${NB_USER}" "/home/${NB_USER}/${server}"
+    done
+else
+    echo "The user already has a configuration file."
+fi
 
-for server in "${ssh_remote_servers[@]}"; do
-    mkdir -p /home/${NB_USER}/${server}/extensions
-    mkdir -p /home/${NB_USER}/${server}/data/User/globalStorage/saoudrizwan.claude-dev/settings/ && \
-    cp /home/${NB_USER}/.local/share/code-server/User/globalStorage/saoudrizwan.claude-dev/settings/cline_mcp_settings.json /home/${NB_USER}/${server}/data/User/globalStorage/saoudrizwan.claude-dev/settings
-    cp /opt/code-server/extensions/extensions.json /home/${NB_USER}/${server}/extensions
-    ln -sf /opt/code-server/extensions/saoudrizwan.claude-dev-3.2.13-universal /home/ies/${server}/extensions
-    mkdir -p /home/${NB_USER}/${server}/extensions
-    chown -Rf "${NB_USER}:${NB_USER}" "/home/${NB_USER}/${server}"
-done
+# Add womtool alias if .bashrc doesn't exist
+if [[ ! -f "/home/${NB_USER}/.bashrc" ]]; then
+    echo "alias womtool='java -jar /usr/local/lib/womtool-85.jar'" >> "/home/${NB_USER}/.bashrc"
+fi
 
+# Set final permissions
 chown "${NB_USER}:${NB_USER}" "/home/${NB_USER}"
 chown -Rf "${NB_USER}:${NB_USER}" "/home/${NB_USER}/.local"
 chown -Rf "${NB_USER}:${NB_USER}" "/home/${NB_USER}/.ssh"
+chown "${NB_USER}:${NB_USER}" "/home/${NB_USER}/.bashrc"
+chown -Rf "${NB_USER}:${NB_USER}" /opt/lib/bioos-mcp-server
+chmod -R 755 "/home/${NB_USER}/.local"


### PR DESCRIPTION
Pre - install the dependencies required by MCP directly inside the container, and use Python to directly run the MCP script, skipping the UV process. In the container environment, it appears that the UV functionality is no longer necessary. However, for the time being, the UV process has been kept intact.
```json
{
  "mcpServers": {
    "bioos": {
      "command": "/opt/conda/bin/python",
      "args": [
        "/opt/lib/bioos-mcp-server/src/bioos_mcp/bioos_mcp_server.py"
      ],
      "env": {
        "PYTHONPATH": "/opt/lib/bioos-mcp-server/src"
      },
      "disabled": false,
      "autoApprove": []
    }
  }
}
```
Meanwhile, the logic for plugin initialization has been modified to ensure that it is predefined only once during the creation process of the IES instance, thus preventing user configuration files from being overwritten upon restart.
```shell
if [[ ! -f "/home/${NB_USER}/.local/share/code-server/User/globalStorage/saoudrizwan.claude-dev/settings/cline_mcp_settings.json" ]]; then
```

