### PR TITLE
feat：新增多文件工作流上传导入功能

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ requires-python = ">=3.10"
 dependencies = [
     "mcp[cli]>=1.2.1",
     "requests>=2.19.1,<2.26.0",
-    "pybioos>=0.0.14"
+    "pybioos>=0.0.15"
 ]
 
 [build-system]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
 requests>=2.19.1
-pybioos>=0.0.14
+pybioos>=0.0.15

--- a/src/bioos_mcp/bioos_mcp_server.py
+++ b/src/bioos_mcp/bioos_mcp_server.py
@@ -8,7 +8,7 @@ import os
 import subprocess
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Any, Dict, List, Tuple
+from typing import Any, Dict, List, Tuple,Optional
 
 import requests
 from mcp.server.fastmcp import FastMCP
@@ -60,6 +60,8 @@ class WorkflowImportConfig:
     workflow_name: str
     workflow_source: str
     workflow_desc: str
+    # 新增：可选的主 WDL 路径，当 `workflow_source` 是目录时，此字段为必填项。请提供主 WDL 文件的路径。
+    main_workflow_path: Optional[str] = None
 
 
 @dataclass
@@ -320,7 +322,30 @@ async def validate_wdl(config: WDLValidateConfig) -> str:
 
 @mcp.tool()
 async def import_workflow(config: WorkflowImportConfig) -> str:
-    """上传 WDL 工作流到 Bio-OS 系统"""
+    """
+    上传 WDL 工作流到 Bio‑OS，请提供以下信息：
+    **必填信息：**
+    • Bio‑OS 访问密钥（ak）
+    • Bio‑OS 私钥（sk）
+    • 工作空间名称（workspace_name）
+    • WDL 源（workflow_source，文件或目录的绝对路径）
+
+    **可选信息：**
+    • 主 WDL 路径（main_workflow_path）：当 `workflow_source` 是目录时，此字段为必填项。请提供主 WDL 文件的路径。
+    • 工作流名称（workflow_name）
+    • 工作流描述（workflow_desc）
+
+    **示例：**
+    如果您上传的是一个目录，请确保提供 `main_workflow_path`：
+    ```
+    workflow_source: /path/to/your/workflow_directory
+    main_workflow_path: /path/to/your/workflow_directory/main.wdl
+    ```
+    如果您上传的是一个单一文件，则无需填写 `main_workflow_path`：
+    ```
+    workflow_source: /path/to/your/workflow.wdl
+    ```
+    """
     cmd = [
         "bw_import", "--ak", config.ak, "--sk", config.sk, "--workspace_name",
         config.workspace_name, "--workflow_name", config.workflow_name,
@@ -328,6 +353,8 @@ async def import_workflow(config: WorkflowImportConfig) -> str:
         config.workflow_desc
     ]
 
+    if config.main_workflow_path:
+        cmd += ["--main_path", config.main_workflow_path]
     result = subprocess.run(cmd, capture_output=True, text=True, check=True)
     # 同时返回 stderr 和 stdout 的内容
     output = []


### PR DESCRIPTION
主要修改：
description: 只包含了工具的用法和大致功能描述。
inputschema: 所有字段的详细描述都放到了 inputschema 中，这里包括了字段名称、类型以及详细的说明。这些信息会被 MCP Server 处理并暴露为工具的参数信息。
工具功能（feat）: 新增多文件工作流上传导入功能，即支持上传单个 WDL 文件或整个目录。

功能：
必填信息：
Bio‑OS 访问密钥（ak）
Bio‑OS 私钥（sk）
工作空间名称（workspace_name）
WDL 源（workflow_source，文件或目录的绝对路径）
可选信息：
主 WDL 文件路径（main_workflow_path）：当 workflow_source 是目录时，此字段为必填项。
工作流描述（workflow_desc）